### PR TITLE
ゲームオーバーダイアログのCSS変更

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -115,13 +115,13 @@ body {
   position: fixed;
   z-index: 2;
   width: 660px;
-  height: 500px;
+  height: 170px;
   background-color: var(--modal);
   top: 0;
   bottom: 0;
   right: 0;
   left: 0;
-  margin: auto;
+  margin: 695px auto;
   border-radius: 30px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
一旦、終了画面が見えるようにリトライダイアログのCSSを変更

<img width="789" alt="image" src="https://github.com/jigintern/ultimate-osechi/assets/1715217/48f6aa9f-9b6a-46e5-89a4-9a464cb6bbcc">
